### PR TITLE
Redis ACL authentication and RBAC support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,5 @@
 #SPDX-License-Identifier: MIT-0
 ---
-# defaults file for redis
-#SPDX-License-Identifier: MIT-0
----
 # Deployment mode
 redis_mode: "standalone"     # standalone | replication
 
@@ -30,3 +27,10 @@ redis_log_file: "/var/log/redis/redis-{{ redis_port }}.log"
 
 # Service
 redis_instance_service: "redis-{{ redis_port }}"
+
+# ACL Configuration
+redis_acl_enabled: false
+
+redis_acl_file: "/etc/redis/users-{{ redis_port }}.acl"
+
+redis_acl_users: []

--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -1,0 +1,9 @@
+- name: Deploy Redis ACL file
+  template:
+    src: users.acl.j2
+    dest: "{{ redis_acl_file }}"
+    owner: redis
+    group: redis
+    mode: '0640'
+  notify:
+    - Restart Redis

--- a/tasks/acl.yml
+++ b/tasks/acl.yml
@@ -1,5 +1,5 @@
-- name: Deploy Redis ACL file
-  template:
+ - name: Deploy Redis ACL file
+  ansible.builtin.template:
     src: users.acl.j2
     dest: "{{ redis_acl_file }}"
     owner: redis
@@ -7,3 +7,4 @@
     mode: '0640'
   notify:
     - Restart Redis
+

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -6,6 +6,13 @@
     group: redis
     mode: '0755'
 
+- name: Ensure Redis data directory ownership
+  file:
+    path: "{{ redis_data_dir }}"
+    owner: redis
+    group: redis
+    recurse: yes
+
 - name: Ensure Redis log directory exists
   file:
     path: "/var/log/redis"
@@ -13,6 +20,14 @@
     owner: redis
     group: redis
     mode: '0755'
+
+- name: Ensure Redis log file exists
+  file:
+    path: "{{ redis_log_file }}"
+    state: touch
+    owner: redis
+    group: redis
+    mode: '0644'
 
 - name: Deploy Redis configuration
   template:
@@ -23,3 +38,4 @@
     mode: '0644'
   notify:
     - Restart Redis
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,5 +7,9 @@
 - name: Configure Redis
   include_tasks: config.yml
 
+- name: Configure Redis ACL
+  include_tasks: acl.yml
+  when: redis_acl_enabled
+
 - name: Configure Redis Service
   include_tasks: service.yml

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -17,6 +17,12 @@
     name: "{{ redis_instance_service }}"
     enabled: yes
 
+- name: Stop existing Redis instance if running
+  systemd:
+    name: "{{ redis_instance_service }}"
+    state: stopped
+  failed_when: false
+
 - name: Start Redis instance
   systemd:
     name: "{{ redis_instance_service }}"

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -17,12 +17,6 @@
     name: "{{ redis_instance_service }}"
     enabled: yes
 
-- name: Stop existing Redis instance if running
-  systemd:
-    name: "{{ redis_instance_service }}"
-    state: stopped
-  failed_when: false
-
 - name: Start Redis instance
   systemd:
     name: "{{ redis_instance_service }}"

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -19,3 +19,10 @@
   when:
     - redis_mode == "replication"
     - redis_role == "replica"
+
+- name: Validate ACL users
+  assert:
+    that:
+      - redis_acl_users | length > 0
+    fail_msg: "redis_acl_users must be defined when redis_acl_enabled=true"
+  when: redis_acl_enabled

--- a/templates/redis-systemd.service.j2
+++ b/templates/redis-systemd.service.j2
@@ -7,7 +7,7 @@ Type=notify
 User=redis
 Group=redis
 
-ExecStart=/usr/bin/redis-server {{ redis_conf_path }} --supervised systemd
+ExecStart=/usr/bin/redis-server {{ redis_conf_path }}
 
 ExecStop=/bin/kill -s TERM $MAINPID
 

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -8,8 +8,12 @@ dir {{ redis_data_dir }}
 daemonize no
 supervised systemd
 
-{% if redis_requirepass %}
+{% if redis_requirepass and not redis_acl_enabled %}
 requirepass {{ redis_password }}
+{% endif %}
+
+{% if redis_acl_enabled %}
+aclfile {{ redis_acl_file }}
 {% endif %}
 
 maxmemory {{ redis_maxmemory }}

--- a/templates/users.acl.j2
+++ b/templates/users.acl.j2
@@ -1,0 +1,3 @@
+{% for user in redis_acl_users %}
+user {{ user.username }} on >{{ user.password }} {{ user.permissions | join(' ') }}
+{% endfor %}


### PR DESCRIPTION
## Summary

Implemented Redis ACL-based authentication and RBAC support for the Redis operator-style Ansible role.

## Changes Added

* Added Redis ACL support using `aclfile`
* Added dynamic ACL template rendering with `users.acl.j2`
* Added support for multiple Redis users with granular permissions
* Added validation for ACL configuration and users
* Improved Redis configuration handling for ACL-based authentication
* Improved Redis systemd service stability and startup handling
* Fixed Redis persistence and permission-related issues
* Improved ownership handling for Redis data and log directories

## Testing Performed

Validated:

* Redis service startup
* ACL authentication flow
* Admin user with full read/write access
* Readonly user with restricted write access
* ACL-based RBAC enforcement

## Next Steps

* Redis health checks
* Replication health validation
* Persistence tuning
* Redis exporter integration
* Production hardening improvements
