### PR TITLE
Add Redis persistence tuning and health validation support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,3 @@
-#SPDX-License-Identifier: MIT-0
----
 # defaults file for redis
 #SPDX-License-Identifier: MIT-0
 ---
@@ -30,3 +28,13 @@ redis_log_file: "/var/log/redis/redis-{{ redis_port }}.log"
 
 # Service
 redis_instance_service: "redis-{{ redis_port }}"
+
+
+# Persistence
+
+redis_save:
+  - "900 1"
+  - "300 10"
+  - "60 10000"
+
+redis_appendfsync: "everysec"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -6,6 +6,13 @@
     group: redis
     mode: '0755'
 
+- name: Ensure Redis data directory ownership
+  file:
+    path: "{{ redis_data_dir }}"
+    owner: redis
+    group: redis
+    recurse: yes
+
 - name: Ensure Redis log directory exists
   file:
     path: "/var/log/redis"
@@ -13,6 +20,14 @@
     owner: redis
     group: redis
     mode: '0755'
+
+- name: Ensure Redis log file exists
+  file:
+    path: "{{ redis_log_file }}"
+    state: touch
+    owner: redis
+    group: redis
+    mode: '0644'
 
 - name: Deploy Redis configuration
   template:

--- a/tasks/healthcheck.yml
+++ b/tasks/healthcheck.yml
@@ -1,0 +1,35 @@
+- name: Verify Redis Ping
+  command: "redis-cli -p {{ redis_port }} ping"
+  register: redis_ping
+  changed_when: false
+
+- name: Fail if Redis is not responding
+  fail:
+    msg: "Redis is not responding on port {{ redis_port }}"
+  when: "'PONG' not in redis_ping.stdout"
+
+- name: Gather Redis service status
+  systemd:
+    name: "{{ redis_instance_service }}"
+  register: redis_service_status
+
+- name: Fail if Redis service is not active
+  fail:
+    msg: "Redis service is not active"
+  when: redis_service_status.status.ActiveState != "active"
+
+- name: Gather Redis replication info
+  command: "redis-cli -p {{ redis_port }} info replication"
+  register: redis_replication_info
+  changed_when: false
+  when:
+    - redis_mode == "replication"
+    - redis_role == "replica"
+
+- name: Fail if replica is not connected to master
+  fail:
+    msg: "Redis replica is not connected to master"
+  when:
+    - redis_mode == "replication"
+    - redis_role == "replica"
+    - "'master_link_status:up' not in redis_replication_info.stdout"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,3 +9,6 @@
 
 - name: Configure Redis Service
   include_tasks: service.yml
+
+- name: Validate Redis Health
+  include_tasks: healthcheck.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,4 +11,4 @@
   include_tasks: service.yml
 
 - name: Validate Redis Health
-  include_tasks: healthcheck.yml
+  include_tasks: runtime_validation.yml

--- a/tasks/runtime_validation.yml
+++ b/tasks/runtime_validation.yml
@@ -1,0 +1,35 @@
+- name: Verify Redis Ping
+  command: "redis-cli -p {{ redis_port }} ping"
+  register: redis_ping
+  changed_when: false
+
+- name: Fail if Redis is not responding
+  fail:
+    msg: "Redis is not responding on port {{ redis_port }}"
+  when: "'PONG' not in redis_ping.stdout"
+
+- name: Gather Redis service status
+  systemd:
+    name: "{{ redis_instance_service }}"
+  register: redis_service_status
+
+- name: Fail if Redis service is not active
+  fail:
+    msg: "Redis service is not active"
+  when: redis_service_status.status.ActiveState != "active"
+
+- name: Gather Redis replication info
+  command: "redis-cli -p {{ redis_port }} info replication"
+  register: redis_replication_info
+  changed_when: false
+  when:
+    - redis_mode == "replication"
+    - redis_role == "replica"
+
+- name: Fail if replica is not connected to master
+  fail:
+    msg: "Redis replica is not connected to master"
+  when:
+    - redis_mode == "replication"
+    - redis_role == "replica"
+    - "'master_link_status:up' not in redis_replication_info.stdout"

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -19,3 +19,9 @@
   when:
     - redis_mode == "replication"
     - redis_role == "replica"
+
+- name: Validate appendfsync policy
+  assert:
+    that:
+      - redis_appendfsync in ['always', 'everysec', 'no']
+    fail_msg: "redis_appendfsync must be always, everysec, or no"

--- a/templates/redis.conf.j2
+++ b/templates/redis.conf.j2
@@ -15,6 +15,12 @@ requirepass {{ redis_password }}
 maxmemory {{ redis_maxmemory }}
 appendonly {{ redis_appendonly }}
 
+appendfsync {{ redis_appendfsync }}
+
+{% for item in redis_save %}
+save {{ item }}
+{% endfor %}
+
 logfile {{ redis_log_file }}
 
 {% if redis_mode == "replication" and redis_role == "replica" %}


### PR DESCRIPTION
## Summary

This PR adds production-grade Redis persistence tuning and operational health validation support to the Redis operator-style Ansible role.

## Features Added

### Persistence Tuning
- Configurable RDB snapshot intervals
- Append Only File (AOF) enable/disable support
- Configurable AOF fsync policies
- Persistence interval customization

### Health Validation
- Redis service health verification
- Redis ping validation
- Replica replication health validation
- Replication link status verification

### Operational Improvements
- Automatic Redis log file creation
- Recursive ownership handling for Redis data directories
- Improved runtime stability for replica deployments

## Testing Performed

- Standalone Redis deployment validation
- Replica deployment validation
- Redis health-check verification
- Replication sync validation
- Local end-to-end testing using Ansible playbooks

Closes #16