### PR TITLE
Add Redis Sentinel support for HA and failover

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,7 +35,7 @@ redis_sentinel_monitor_name: "mymaster"
 redis_sentinel_quorum: 2
 redis_sentinel_down_after_milliseconds: 5000
 redis_sentinel_failover_timeout: 60000
-
+redis_sentinel_service_name: "redis-sentinel"
 redis_sentinel_dir: "/var/lib/redis-sentinel"
 
 # Sentinel Authentication

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,5 @@
 #SPDX-License-Identifier: MIT-0
 ---
-# defaults file for redis
-#SPDX-License-Identifier: MIT-0
----
 # Deployment mode
 redis_mode: "standalone"     # standalone | replication
 
@@ -30,3 +27,18 @@ redis_log_file: "/var/log/redis/redis-{{ redis_port }}.log"
 
 # Service
 redis_instance_service: "redis-{{ redis_port }}"
+
+# Sentinel Configuration
+redis_sentinel_enabled: false
+redis_sentinel_port: 26379
+redis_sentinel_monitor_name: "mymaster"
+redis_sentinel_quorum: 2
+redis_sentinel_down_after_milliseconds: 5000
+redis_sentinel_failover_timeout: 60000
+
+redis_sentinel_dir: "/var/lib/redis-sentinel"
+
+# Sentinel Authentication
+redis_sentinel_auth_user: ""
+
+redis_sentinel_auth_pass: ""

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,7 +7,9 @@
   systemd:
     daemon_reload: yes
 
+
 - name: Restart Redis Sentinel
   systemd:
-    name: "redis-sentinel-{{ redis_sentinel_port }}"
+    name: "{{ redis_sentinel_service_name }}"
     state: restarted
+

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,3 +6,8 @@
 - name: Reload systemd
   systemd:
     daemon_reload: yes
+
+- name: Restart Redis Sentinel
+  systemd:
+    name: "redis-sentinel-{{ redis_sentinel_port }}"
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,3 +9,11 @@
 
 - name: Configure Redis Service
   include_tasks: service.yml
+
+- name: Configure Redis Sentinel
+  include_tasks: sentinel.yml
+  when: redis_sentinel_enabled
+
+- name: Validate Redis Sentinel
+  include_tasks: sentinel_healthcheck.yml
+  when: redis_sentinel_enabled

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -1,0 +1,49 @@
+- name: Ensure Redis Sentinel directory exists
+  file:
+    path: "{{ redis_sentinel_dir }}"
+    state: directory
+    owner: redis
+    group: redis
+    mode: '0755'
+
+- name: Ensure Sentinel log file exists
+  file:
+    path: "/var/log/redis/sentinel-{{ redis_sentinel_port }}.log"
+    state: touch
+    owner: redis
+    group: redis
+    mode: '0644'
+
+- name: Deploy Redis Sentinel configuration
+  template:
+    src: sentinel.conf.j2
+    dest: "/etc/redis/sentinel-{{ redis_sentinel_port }}.conf"
+    owner: redis
+    group: redis
+    mode: '0644'
+  notify:
+    - Restart Redis Sentinel
+
+- name: Deploy Redis Sentinel systemd service
+  template:
+    src: redis-sentinel.service.j2
+    dest: "/etc/systemd/system/redis-sentinel-{{ redis_sentinel_port }}.service"
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - Reload systemd
+    - Restart Redis Sentinel
+
+- name: Flush handlers
+  meta: flush_handlers
+
+- name: Enable Redis Sentinel service
+  systemd:
+    name: "redis-sentinel-{{ redis_sentinel_port }}"
+    enabled: yes
+
+- name: Start Redis Sentinel service
+  systemd:
+    name: "redis-sentinel-{{ redis_sentinel_port }}"
+    state: started

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -8,7 +8,7 @@
 
 - name: Ensure Sentinel log file exists
   file:
-    path: "/var/log/redis/sentinel-{{ redis_sentinel_port }}.log"
+    path: "/var/log/redis/sentinel.log"
     state: touch
     owner: redis
     group: redis
@@ -17,7 +17,7 @@
 - name: Deploy Redis Sentinel configuration
   template:
     src: sentinel.conf.j2
-    dest: "/etc/redis/sentinel-{{ redis_sentinel_port }}.conf"
+    dest: "/etc/redis/sentinel.conf"
     owner: redis
     group: redis
     mode: '0644'
@@ -27,7 +27,7 @@
 - name: Deploy Redis Sentinel systemd service
   template:
     src: redis-sentinel.service.j2
-    dest: "/etc/systemd/system/redis-sentinel-{{ redis_sentinel_port }}.service"
+    dest: "/etc/systemd/system/{{ redis_sentinel_service_name }}.service"
     owner: root
     group: root
     mode: '0644'
@@ -40,10 +40,10 @@
 
 - name: Enable Redis Sentinel service
   systemd:
-    name: "redis-sentinel-{{ redis_sentinel_port }}"
+    name: "{{ redis_sentinel_service_name }}"
     enabled: yes
 
 - name: Start Redis Sentinel service
   systemd:
-    name: "redis-sentinel-{{ redis_sentinel_port }}"
+    name: "{{ redis_sentinel_service_name }}"
     state: started

--- a/tasks/sentinel_healthcheck.yml
+++ b/tasks/sentinel_healthcheck.yml
@@ -1,0 +1,19 @@
+- name: Verify Redis Sentinel ping
+  command: "redis-cli -p {{ redis_sentinel_port }} ping"
+  register: sentinel_ping
+  changed_when: false
+
+- name: Fail if Sentinel is not responding
+  fail:
+    msg: "Redis Sentinel is not responding"
+  when: "'PONG' not in sentinel_ping.stdout"
+
+- name: Gather Sentinel master information
+  command: "redis-cli -p {{ redis_sentinel_port }} sentinel masters"
+  register: sentinel_master_info
+  changed_when: false
+
+- name: Fail if Sentinel is not monitoring master
+  fail:
+    msg: "Redis Sentinel is not monitoring the configured master"
+  when: redis_sentinel_monitor_name not in sentinel_master_info.stdout

--- a/tasks/validate.yml
+++ b/tasks/validate.yml
@@ -19,3 +19,10 @@
   when:
     - redis_mode == "replication"
     - redis_role == "replica"
+
+- name: Validate Sentinel configuration
+  assert:
+    that:
+      - redis_master_ip | length > 0
+    fail_msg: "redis_master_ip is required when redis_sentinel_enabled=true"
+  when: redis_sentinel_enabled

--- a/templates/redis-sentinel.service.j2
+++ b/templates/redis-sentinel.service.j2
@@ -7,7 +7,7 @@ Type=simple
 User=redis
 Group=redis
 
-ExecStart=/usr/bin/redis-server /etc/redis/sentinel-{{ redis_sentinel_port }}.conf --sentinel
+ExecStart=/usr/bin/redis-server /etc/redis/sentinel.conf --sentinel
 
 Restart=always
 RestartSec=5

--- a/templates/redis-sentinel.service.j2
+++ b/templates/redis-sentinel.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Redis Sentinel
+After=network.target
+
+[Service]
+Type=simple
+User=redis
+Group=redis
+
+ExecStart=/usr/bin/redis-server /etc/redis/sentinel-{{ redis_sentinel_port }}.conf --sentinel
+
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/sentinel.conf.j2
+++ b/templates/sentinel.conf.j2
@@ -1,0 +1,22 @@
+port {{ redis_sentinel_port }}
+
+dir {{ redis_sentinel_dir }}
+
+sentinel monitor {{ redis_sentinel_monitor_name }} {{ redis_master_ip }} {{ redis_master_port }} {{ redis_sentinel_quorum }}
+
+{% if redis_sentinel_auth_user | length > 0 %}
+sentinel auth-user {{ redis_sentinel_monitor_name }} {{ redis_sentinel_auth_user }}
+{% endif %}
+
+{% if redis_sentinel_auth_pass | length > 0 %}
+sentinel auth-pass {{ redis_sentinel_monitor_name }} {{ redis_sentinel_auth_pass }}
+{% endif %}
+
+
+sentinel down-after-milliseconds {{ redis_sentinel_monitor_name }} {{ redis_sentinel_down_after_milliseconds }}
+
+sentinel failover-timeout {{ redis_sentinel_monitor_name }} {{ redis_sentinel_failover_timeout }}
+
+logfile /var/log/redis/sentinel-{{ redis_sentinel_port }}.log
+
+protected-mode no

--- a/templates/sentinel.conf.j2
+++ b/templates/sentinel.conf.j2
@@ -17,6 +17,6 @@ sentinel down-after-milliseconds {{ redis_sentinel_monitor_name }} {{ redis_sent
 
 sentinel failover-timeout {{ redis_sentinel_monitor_name }} {{ redis_sentinel_failover_timeout }}
 
-logfile /var/log/redis/sentinel-{{ redis_sentinel_port }}.log
+logfile /var/log/redis/sentinel.log
 
 protected-mode no


### PR DESCRIPTION
## Overview

Implemented Redis Sentinel support for High Availability (HA) in the Redis Ansible role.

## Features Added

* Redis Sentinel configuration automation
* Sentinel systemd service management
* Configurable Sentinel parameters
* Sentinel health validation tasks
* Master monitoring and failover support
* Sentinel authentication support compatible with password and ACL-based Redis deployments
* Automated Sentinel deployment through role integration

## Validation Performed

* Validated Sentinel deployment and health checks locally
* Verified Sentinel monitoring of Redis master
* Successfully tested automatic failover workflow
* Verified automatic replica promotion during master failure
* Validated topology reconciliation after old master recovery
* Confirmed old master rejoined automatically as replica after recovery

## Files Added

* tasks/sentinel.yml
* tasks/sentinel_healthcheck.yml
* templates/sentinel.conf.j2
* templates/redis-sentinel.service.j2

## Files Updated

* defaults/main.yml
* tasks/main.yml
* tasks/validate.yml
* handlers/main.yml
